### PR TITLE
Github -> GitHub

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,6 @@ A number of activities are organised by the community:
 For more information check the following [Wiki](https://github.com/singlesourcepub/community/wiki) & [discussion board](https://github.com/singlesourcepub/community/discussions). 
 
 ---
-Single Source Publishing Community (SSPC) — Unless otherwise stated: All content © The Authors 2021, Licensed as Creative Commons — Attribution-ShareAlike 4.0 International ([CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.ast)) from this [Github repository](https://github.com/singlesourcepub/community). See [here](https://github.com/singlesourcepub/community/wiki/Terms-and-Conditions) for more details. Please see our community [Code of Conduct](Code-of-Conduct).
+Single Source Publishing Community (SSPC) — Unless otherwise stated: All content © The Authors 2021, Licensed as Creative Commons — Attribution-ShareAlike 4.0 International ([CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.ast)) from this [GitHub repository](https://github.com/singlesourcepub/community). See [here](https://github.com/singlesourcepub/community/wiki/Terms-and-Conditions) for more details. Please see our community [Code of Conduct](Code-of-Conduct).
 
 [Imprint](docs/imprint.md) : [Data privacy](https://docs.github.com/en/github/site-policy/github-privacy-statement)


### PR DESCRIPTION
Once spotted, this typo cannot be unseen (by me anyway 😆)